### PR TITLE
Update backend.py

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -357,7 +357,7 @@ def list_subs(table, part_num):
                     part_dict["physical_size"],
                     part_dict["connector"],
                     part_dict["ssd_capacity"],
-                    part_dict["interface"][:1] + "%",
+                    part_dict["interface"],
                 )
             else:
                 sql = (


### PR DESCRIPTION
For the m.2 drives the SQL being generated was looking for units with a "G" interface. I changed it so it now matches the interface of the parts. So, G3x4 matches with G3x4 and G4x4 will only match with G4x4.